### PR TITLE
#70 - access HTTP headers from resource

### DIFF
--- a/src/read_array_cache.coffee
+++ b/src/read_array_cache.coffee
@@ -34,8 +34,7 @@ module.exports = readArrayCache = ($q, providerParams, name, CachedResource, act
       cacheArrayEntry.addInstances(instances, false)
 
     readHttp = ->
-      resource = CachedResource.$resource[name](params)
-      resource.$promise.then (response) ->
+      resource = CachedResource.$resource[name](params, (response, headers) ->
         newArrayInstance = new Array()
 
         response.map (resourceInstance) ->
@@ -49,12 +48,14 @@ module.exports = readArrayCache = ($q, providerParams, name, CachedResource, act
             newArrayInstance.push resourceInstance
 
         arrayInstance.splice(0, arrayInstance.length, newArrayInstance...)
+        arrayInstance.$headers = headers()
 
         cacheDeferred.resolve arrayInstance unless cacheArrayEntry.value
         httpDeferred.resolve arrayInstance
-      resource.$promise.catch (error) ->
+      , (error) ->
         cacheDeferred.reject error unless cacheArrayEntry.value
         httpDeferred.reject error
+      )
 
     if not actionConfig.cacheOnly
       CachedResource.$writes.flush readHttp


### PR DESCRIPTION
This makes the HTTP headers accessible when doing a query request (reading an array) in a .headers attribute in the response.